### PR TITLE
Use the action name as the check name

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -1,14 +1,12 @@
 const request = require('./request')
 
-const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_TOKEN, GITHUB_WORKSPACE } = process.env
+const { GITHUB_SHA, GITHUB_EVENT_PATH, GITHUB_TOKEN, GITHUB_WORKSPACE, GITHUB_ACTION } = process.env
 const event = require(GITHUB_EVENT_PATH)
 const { repository } = event
 const {
   owner: { login: owner }
 } = repository
 const { name: repo } = repository
-
-const checkName = 'ESLint check'
 
 const headers = {
   'Content-Type': 'application/json',
@@ -19,7 +17,7 @@ const headers = {
 
 async function createCheck() {
   const body = {
-    name: checkName,
+    name: GITHUB_ACTION,
     head_sha: GITHUB_SHA,
     status: 'in_progress',
     started_at: new Date()
@@ -64,7 +62,7 @@ function eslint() {
   return {
     conclusion: errorCount > 0 ? 'failure' : 'success',
     output: {
-      title: checkName,
+      title: GITHUB_ACTION,
       summary: `${errorCount} error(s), ${warningCount} warning(s) found`,
       annotations
     }
@@ -73,7 +71,7 @@ function eslint() {
 
 async function updateCheck(id, conclusion, output) {
   const body = {
-    name: checkName,
+    name: GITHUB_ACTION,
     head_sha: GITHUB_SHA,
     status: 'completed',
     completed_at: new Date(),


### PR DESCRIPTION
If someone renames the action within their workflow, the renamed action hangs around in an `in_progress` state and the results show up as a separate check. This should ensure that the results are shown as part of the action.